### PR TITLE
Make starwars play again

### DIFF
--- a/apps/txtplayer.c
+++ b/apps/txtplayer.c
@@ -1,7 +1,4 @@
 #include <yehos.h>
-#include <string.h>
-
-#include "video.h"
 
 #define MOVIE_ADDR 0x70000000
 

--- a/apps/video.c
+++ b/apps/video.c
@@ -1,12 +1,4 @@
-
-#include <string.h>
-#if 0
-#include "ourtypes.h"
-#include "vgatext.h"
-#include "kernel.h"
-#include "asmhelpers.h"
-#include "globals.h"
-#endif
+#include <yehos.h>
 
 static volatile char *videomem = (volatile char *) 0xb8000;
 
@@ -19,24 +11,19 @@ volatile int seek = 0;
 void play_video(char * pic_index) {
 
     show_image(pic_index, 4000);
-#if 0
-    int last_timer_index = timer_index;
+    int last_timer_index = get_timer_index();
 
     while(1) {
-//        usleep(300000);
-        halt();
-        if (last_timer_index != timer_index) {
-            last_timer_index = timer_index;
-            if(!pause_set) {
-                show_image(pic_index + seek * 4000, 4000);
-                seek++;
-            }
+        yield();
+        if (last_timer_index != get_timer_index()) {
+            last_timer_index = get_timer_index();
+            show_image(pic_index + seek * 4000, 4000);
+            seek++;
 
             // boundaries
-            if(seek < 0) seek = 0;
-            if (seek > 13460) seek=13460;
+            if (seek < 0) seek = 0;
+            if (seek > 13460) seek = 13460;
         }
     }
-#endif
 
 }

--- a/ata.c
+++ b/ata.c
@@ -235,7 +235,7 @@ int ata_status_notbusy(ata_disk *d)
 {
     u8 st = ata_in8(d, CB_ALT_STATUS);
     int ntries;
-    for (ntries=0; ntries < 10000; ntries++)
+    for (ntries=0; ntries < 100000; ntries++)
     {
         u8 status = ata_in8(d, CB_ALT_STATUS);
         if (status & CB_STATUS_ERR)

--- a/libyehos.c
+++ b/libyehos.c
@@ -68,6 +68,11 @@ yield()
 
 }
 
+int
+get_timer_index() {
+    return (int) syscall(8, NULL);
+}
+
 void clear_screen() {
     int col, row;
     for (row = 0; row < 25; row++) {

--- a/syscalls.c
+++ b/syscalls.c
@@ -112,6 +112,10 @@ syscall_handler(int syscall_num, const void *parms)
 
             return;
         }
+    case 8: // get_timer_index
+        {
+            return timer_index;
+        }
     default:
         kprintf("system call %d not supported\n", syscall_num);
         break;

--- a/virtualmem.c
+++ b/virtualmem.c
@@ -97,7 +97,7 @@ handle_page_fault()
     }
     else if ((ptable_entry >> 28) == 4) {
         // "Use the fours"
-        uint32_t lba = (ptable_entry & ~(uint32_t) 0xf0000000) >> 4;
+        uint32_t lba = (ptable_entry & ~(uint32_t) 0xf0000000) >> 12;
         ata_disk *d = &disks[0];
         char *diskbuf = (void *) 0x90000;
         while (atapi_read_lba(d, diskbuf, 0xffff, lba, 2) < 0) {
@@ -115,7 +115,7 @@ mmap_disk(ata_disk *d) {
     for (uint32_t i = 0; i < npages; i++) {
         uint32_t lba = i * page_size / d->sector_size;
         uint32_t page_table_index = i + (ISO_START >> 12);
-        ptable[page_table_index] = DISK_MEMORY_ADDR_FLAG + (lba << 4); // 0x4[lba]0
+        ptable[page_table_index] = DISK_MEMORY_ADDR_FLAG + (lba << 12); // 0x4[lba]000
     }
 }
 
@@ -147,7 +147,7 @@ mmap(char *filename, uint32_t virt_addr){
     // mmap the file to the given virt addr using "the fours" scheme.
     // (assumes ratio of sector size to page size is 1 : 2
     for(uint32_t lba = 0; lba < num_lbas; lba += 2)
-        ptable[(virt_addr >> 12) + lba/2] = DISK_MEMORY_ADDR_FLAG + ((first_lba + lba) << 4); //0x4[lba]0
+        ptable[(virt_addr >> 12) + lba/2] = DISK_MEMORY_ADDR_FLAG + ((first_lba + lba) << 12); //0x4[lba]000
     return 0;
 }
 

--- a/yehos.h
+++ b/yehos.h
@@ -23,6 +23,9 @@ scroll();
 void
 yield();
 
+int
+get_timer_index();
+
 void
 setcursor(int x, int y);
 


### PR DESCRIPTION
* Increase timeout for reading from iso
* Make txtplayer.c into a real application that calls core yehos code via syscalls
* Shift metadata about memory-mapped content from iso over farther so it doesn't conflict with page table flags

Requires changing application to "TXTPLAYR.BIN" in kmain.c to test.